### PR TITLE
fix(marketplace): replace invalid git-subdir source with string path

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -14,13 +14,7 @@
             "name": "gaia-foundation",
             "description": "Spec-driven AI agents for software architecture, planning, engineering, testing, and release workflows.",
             "version": "8.1.0",
-            "source": {
-                "source": "git-subdir",
-                "url": "https://github.com/frostaura/ai.toolkit.gaia.git",
-                "path": ".github",
-                "ref": "main",
-                "_sha": "56273e0e20762d76640838300a7431c4260cad32"
-            }
+            "source": ".github"
         }
     ]
 }


### PR DESCRIPTION
## Problem

Running `copilot plugin marketplace add frostaura/ai.toolkit.gaia` fails with:

`Failed to add marketplace: Invalid marketplace.json: plugins.0.source: Invalid input`

## Root Cause

The source field used an object with source: git-subdir, which is not a valid source type for the Copilot CLI plugin marketplace schema. The CLI only accepts a string (relative path) as the source value.

## Fix

Replace the object with a simple relative string path .github pointing to the plugin directory. The agents/ and skills/ subdirectories already exist under .github/ and will be auto-detected by the CLI.
