### PR TITLE
fix(version): align plugin and marketplace versions to v9.0.0 closes#58

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         {
             "name": "gaia-foundation",
             "description": "Spec-driven AI agents for software architecture, planning, engineering, testing, and release workflows.",
-            "version": "8.1.0",
+            "version": "9.0.0",
             "source": {
                 "source": "git-subdir",
                 "url": "https://github.com/frostaura/ai.toolkit.gaia.git",

--- a/.github/.claude-plugin/plugin.json
+++ b/.github/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "gaia-foundation",
     "description": "Gaia Foundation is a powerful automated, enterprise-grade software architecture, engineering, and development agent designed to streamline the software development lifecycle. It leverages advanced AI capabilities to assist developers in creating high-quality software efficiently and consistently.",
-    "version": "8.1.0",
+    "version": "9.0.0",
     "author": {
         "name": "FrostAura Technologies",
         "email": "support-gaia@frostaura.net"

--- a/marketplace.json
+++ b/marketplace.json
@@ -13,7 +13,7 @@
         {
             "name": "gaia-foundation",
             "description": "Spec-driven AI agents for software architecture, planning, engineering, testing, and release workflows.",
-            "version": "8.1.0",
+            "version": "9.0.0",
             "source": ".github"
         }
     ]


### PR DESCRIPTION
README badge advertised Version 9 while plugin.json and both marketplace.json files still declared 8.1.0, creating a mismatch visible to any user installing from the marketplace.